### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.5
 # - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 os:
   - linux
+  - osx
 julia:
   - 0.5
 # - nightly


### PR DESCRIPTION
release will change over time, but since the package supports 0.5 in REQUIRE,
it should continue to be tested