### PR TITLE
Add size(::SymmetricTensor) and pyramidindices(::SymmetricTensor)

### DIFF
--- a/src/SymmetricTensors.jl
+++ b/src/SymmetricTensors.jl
@@ -24,5 +24,5 @@ module SymmetricTensors
   include("randgendat.jl")
 
   export SymmetricTensor, convert, +, -, *, /, unfold, diag, rand,
-         ArrayNArrays, arraynarrays, setindex!
+         ArrayNArrays, arraynarrays, setindex!, pyramidindices
 end

--- a/src/symmetrictensor.jl
+++ b/src/symmetrictensor.jl
@@ -128,6 +128,13 @@ function pyramidindices(dims::Int, tensize::Int)
 end
 
 """
+    pyramidindices(st::SymmetricTensor)
+
+Return the indices of the unique element of the give symmetric tensor.
+"""
+pyramidindices(st::SymmetricTensor{<:Any, N}) where N = pyramidindices(N, st.dats)
+
+"""
 
     sizetest(dats::Int, bls::Int)
 
@@ -158,6 +165,13 @@ function getblock(st::SymmetricTensor, mulind::Tuple)
   ind = sortperm([mulind...])
   permutedims(getblockunsafe(st, mulind[ind]), invperm(ind))
 end
+
+"""
+    size(st::SymmetricTensor)
+
+Return the size of a symmetric tensor.
+"""
+size(st::SymmetricTensor{<:Any, N}) where N = ntuple(i -> st.dats, N)
 
 """
     getindex(st::SymmetricTensor, mulind::Tuple)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,28 @@ Random.seed!(42)
 t = randsymarray(7, 3)
 t1 = randsymarray(7, 3)
 
+@testset "Indices" begin
+  st = SymmetricTensor(t, 3)
+  @testset "Size" begin
+    @test size(st) == (7, 7, 7)
+  end
+  @testset "Pyramid indices" begin
+    pinds = pyramidindices(3, 7)
+    found = 0
+
+    for i in 1:7
+      for j in i:7
+        for k in j:7
+          if (i, j, k) in pinds
+            found += 1
+          end
+        end
+      end
+    end
+    @test found == length(pinds)
+    @test pyramidindices(st) == pinds
+  end
+end
 
 @testset "Converting" begin
   b = SymmetricTensor(t, 3)


### PR DESCRIPTION
Hi everyone !

In this PR I just added two small convenience functions that I find usefull to iterate over symmetric tensors.